### PR TITLE
Updated per feedback

### DIFF
--- a/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
+++ b/src/BenchmarkDotNet/ConsoleArguments/ConfigParser.cs
@@ -774,10 +774,17 @@ namespace BenchmarkDotNet.ConsoleArguments
         internal static bool TryParse(string runtime, out RuntimeMoniker runtimeMoniker)
         {
             int index = runtime.IndexOf('-');
+            if (index >= 0)
+            {
+                runtime = runtime.Substring(0, index);
+            }
 
-            return index < 0
-                ? Enum.TryParse<RuntimeMoniker>(runtime.Replace(".", string.Empty), ignoreCase: true, out runtimeMoniker)
-                : Enum.TryParse<RuntimeMoniker>(runtime.Substring(0, index).Replace(".", string.Empty), ignoreCase: true, out runtimeMoniker);
+            // Monikers older than Net 10 don't use any version delimiter, newer monikers use _ delimiter.
+            if (Enum.TryParse(runtime.Replace(".", string.Empty), ignoreCase: true, out runtimeMoniker))
+            {
+                return true;
+            }
+            return Enum.TryParse(runtime.Replace('.', '_'), ignoreCase: true, out runtimeMoniker);
         }
     }
 }

--- a/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
+++ b/tests/BenchmarkDotNet.Tests/ConfigParserTests.cs
@@ -383,12 +383,12 @@ namespace BenchmarkDotNet.Tests
         }
 
         [Theory]
-        [InlineData("net50")]
-        [InlineData("net60")]
-        [InlineData("net70")]
-        [InlineData("net80")]
-        [InlineData("net90")]
-        [InlineData("net10_0")]
+        [InlineData("net5.0")]
+        [InlineData("net6.0")]
+        [InlineData("net7.0")]
+        [InlineData("net8.0")]
+        [InlineData("net9.0")]
+        [InlineData("net10.0")]
         public void NetMonikersAreRecognizedAsNetCoreMonikers(string tfm)
         {
             var config = ConfigParser.Parse(new[] { "-r", tfm }, new OutputLogger(Output)).config;


### PR DESCRIPTION
Updated per feedback. Updated the ConfigParser TryParse method to take into account _s in net10.0 and beyond enum names, and updated the ConfigParserTests to take this update into account.